### PR TITLE
Adding setup scripts for ios, android and react-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# mobile-setup
+# Mobile setup scripts for iOS, Android, and React Native

--- a/bin/setup-android
+++ b/bin/setup-android
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+brew cask install java
+brew cask install android-studio
+brew cask install android-sdk
+brew cask install android-ndk
+brew cask install gradle
+
+echo "Add the following:"
+echo "--------------------------------------------"
+echo "export ANDROID_SDK_ROOT=/usr/local/share/android-sdk"
+echo "export ANDROID_HOME=/usr/local/share/android-sdk"
+echo "export ANDROID_NDK_HOME=/usr/local/share/android-ndk"
+echo "export PATH=\$PATH:${ANDROID_HOME}/tools"
+echo "export PATH=\$PATH:${ANDROID_HOME}/platform-tools"
+echo "--------------------------------------------"

--- a/bin/setup-ios
+++ b/bin/setup-ios
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+xcode-select --install
+sudo xcode-select -s /Applications/Xcode.app

--- a/bin/setup-react-native
+++ b/bin/setup-react-native
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+brew install node watchman


### PR DESCRIPTION
These are the most basic pieces needed to get to project-specific setup, so it doesn't include adding react-native-cli, or setting up emulators or android packages, or even the deployment gem - just focusing on the idea of safely assuming the person setting up the project has X installed already.